### PR TITLE
Quickfixing a couple of type errors (libkbfs.KeyGen vs int/int64)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -350,7 +350,7 @@ func (c *Client) SearchWord(directory, word string) ([]string, error) {
 	for _, keyGen := range keyGens {
 		origKeyGen := keyGen
 		if keyGen == int(libkbfs.PublicKeyGen) {
-			keyGen = libkbfs.FirstValidKeyGen
+			keyGen = int(libkbfs.FirstValidKeyGen)
 		}
 		if keyGen < 0 || getNormalizedKeyIndex(libkbfs.KeyGen(keyGen)) > dirInfo.getLatestKeyIndex() {
 			continue

--- a/libsearch/util.go
+++ b/libsearch/util.go
@@ -211,7 +211,7 @@ func DocIDToPathname(docID sserver1.DocumentID, keys []PathnameKeyType) (string,
 	if err := binary.Read(versionBuf, binary.LittleEndian, &keyGen); err != nil {
 		return "", err
 	}
-	key := keys[keyGen-libkbfs.FirstValidKeyGen]
+	key := keys[keyGen-int64(libkbfs.FirstValidKeyGen)]
 	keyBytes := [32]byte(key)
 
 	var nonce [docIDNonceLength]byte


### PR DESCRIPTION
Now `go get github.com/keybase/search/client/client` succeeds.